### PR TITLE
Feature: One Word per Document Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ On top of that, for each word the database also contains the number of associate
 The _documents_ table also contains the number of occurrences of the associated word within the document. We use this information for scoring
 within the search part of our engine.
 
+_Note: The indexer uses different entries in the words table for the same word, if the indexed documents are different. This is done in order
+to avoid search pollution of documents by documents of different type. Also, the way Laravel implements its search, indexes of different document
+types are expected to be separated as well._
+
 #### The Search
 
 When executing a search query, the same tokenizing and stemming process as used for indexing is applied to the search query string. The result of

--- a/migrations/create_scout_database_words_table.php
+++ b/migrations/create_scout_database_words_table.php
@@ -20,12 +20,13 @@ class CreateScoutDatabaseWordsTable extends Migration
     {
         Schema::connection(config('scout-database.connection'))->create('scout_words', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->string('document_type');
             $table->string('term', '1024');
             $table->unsignedInteger('num_hits');
             $table->unsignedInteger('num_documents');
             $table->unsignedInteger('length');
 
-            $table->unique('term');
+            $table->unique(['document_type', 'term']);
         });
     }
 


### PR DESCRIPTION
To avoid pollution of search results from other document types, the `words` table should use one entry per `term` and `document_type`. This change only affects indexing, as the search part will only retrieve documents (and their associated words) of a specific type anyway.