### PR TITLE
Fix potential division-by-zero in DatabaseSeeker

### DIFF
--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -170,8 +170,8 @@ class DatabaseSeeker
                 '(' .
                     '(1 + LOG(? * (info.cnt / ((CASE WHEN w.num_documents > 1 THEN w.num_documents ELSE 1 END) + 1))))' . // inverse document frequency
                     '* (' .
-                        '(CAST(? as float) * SQRT(d.num_hits))' .             // weighted term frequency
-                        '+ (CAST(? as float) * SQRT(1/(w.length - ? + 1)))' . // term deviation (for wildcard search)
+                        '(CAST(? as float) * SQRT(d.num_hits))' .                    // weighted term frequency
+                        '+ (CAST(? as float) * SQRT(1 / (ABS(w.length - ?) + 1)))' . // term deviation (for wildcard search)
                     ')' .
                 ') as score',
                 [


### PR DESCRIPTION
Depending on the query execution plan generated by the query optimizer, it is possible that a division-by-zero is encountered in the select by the query engine. This PR solves the issue by calculating an absolute value for the score at this point.

In reality, this isn't really possible due to the where condition `where('w.term', 'like', $keyword)` though. When `w.term` matches `$keyword` (which is `xyz` or `xyz%` for example), then `w.term` has at least the same length as `$keyword` (without the wildcard `%`) and therefore `(w.length - ? + 1)` (where `?` is the length of `$keyword`) must be `1` or greater.