### PR TITLE
Fix potential precision issue with division in DatabaseSeeker

### DIFF
--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -168,10 +168,10 @@ class DatabaseSeeker
             ])
             ->selectRaw(
                 '(' .
-                    '(1 + LOG(? * (info.cnt / ((CASE WHEN w.num_documents > 1 THEN w.num_documents ELSE 1 END) + 1))))' . // inverse document frequency
+                    '(1 + LOG(? * (CAST(info.cnt as float) / ((CASE WHEN w.num_documents > 1 THEN w.num_documents ELSE 1 END) + 1))))' . // inverse document frequency
                     '* (' .
-                        '(CAST(? as float) * SQRT(d.num_hits))' .                    // weighted term frequency
-                        '+ (CAST(? as float) * SQRT(1 / (ABS(w.length - ?) + 1)))' . // term deviation (for wildcard search)
+                        '(CAST(? as float) * SQRT(d.num_hits))' .                                   // weighted term frequency
+                        '+ (CAST(? as float) * SQRT(CAST(1 as float) / (ABS(w.length - ?) + 1)))' . // term deviation (for wildcard search)
                     ')' .
                 ') as score',
                 [


### PR DESCRIPTION
Because the DatabaseSeeker is querying integer values which are then used for mathematical operations like division in some places, it is possible that different DBMS produce weird or wrong results for the division. As an example, the division of `1022/1023` is evaluated to `0` by SQL Server 2017 but to `0.9990` by MySQL and MariaDB. By casting the integers to floats prior to the division, this problem is solved. 

Besides the fact that the search is not throwing exceptions, the score of the search is also more precise doing it this way.