### PR TITLE
Improve the performance of the indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ has been added for each of them:
 If you have different requirements for a stemmer, you can provide your own implementation via the configuration. Just make sure it implements the
 [`Stemmer`](src/Contracts/Stemmer.php) interface.
 
+### Keeping the Search Index clean
+
+By default, the database indexer will ensure the word index is kept clean with each index update. This may have a negative impact on the performance
+of the indexing process though. It is therefore possible and also recommended to opt out of the auto-cleaning and run a manual or scheduled
+cleaning job instead.
+
+In order to do so, the setting `clean_words_table_on_every_update` must be set to `false` in the configuration.
+Optionally (but recommended), the `\Namoshek\Scout\Database\Commands\CleanWordsTable` command should be scheduled to run regularly depending on
+the update frequency of your search index within the `schedule(Schedule $schedule)` method of your console `Kernel`:
+```php
+protected function schedule(Schedule $schedule)
+{
+    $schedule->command(\Namoshek\Scout\Database\Commands\CleanWordsTable::class)->daily();
+}
+```
+
 ## Usage
 
 The package follows the available use cases described in the [official Scout documentation](https://laravel.com/docs/7.x/scout).

--- a/config/scout-database.php
+++ b/config/scout-database.php
@@ -64,6 +64,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Clean the Words Table on every Update
+    |--------------------------------------------------------------------------
+    |
+    | If this setting is enabled, entries in the words table associated with
+    | no documents are removed on every update of the search index.
+    |
+    | Disabling this setting may improve the speed of the indexing process
+    | significantly. It is recommended to run the cleanup command as scheduled
+    | job on a regular basis instead though. See the documentation for more
+    | details.
+    |
+    */
+
+    'clean_words_table_on_every_update' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Search related Settings
     |--------------------------------------------------------------------------
     |

--- a/src/Commands/CleanWordsTable.php
+++ b/src/Commands/CleanWordsTable.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Namoshek\Scout\Database\Commands;
+
+use Illuminate\Console\Command;
+use Namoshek\Scout\Database\DatabaseIndexer;
+
+/**
+ * Removes entries from the Laravel Scout words table without associated documents.
+ *
+ * @package Namoshek\Scout\Database\Commands
+ */
+class CleanWordsTable extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'scout:clean-words-table';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Removes entries from the Scout words table without associated documents';
+
+    /**
+     * Execute the console command.
+     *
+     * @param DatabaseIndexer $databaseIndexer
+     * @return void
+     */
+    public function handle(DatabaseIndexer $databaseIndexer): void
+    {
+        $databaseIndexer->deleteWordsWithoutAssociatedDocuments();
+    }
+}

--- a/src/IndexingConfiguration.php
+++ b/src/IndexingConfiguration.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Namoshek\Scout\Database;
+
+/**
+ * A simple wrapper for the indexing configuration.
+ *
+ * @package Namoshek\Scout\Database
+ */
+class IndexingConfiguration
+{
+    /** @var bool */
+    protected $cleanWordsTableOnEveryUpdate;
+
+    /**
+     * IndexingConfiguration constructor.
+     *
+     * @param bool $cleanWordsTableOnEveryUpdate
+     */
+    public function __construct(bool $cleanWordsTableOnEveryUpdate)
+    {
+        $this->cleanWordsTableOnEveryUpdate = $cleanWordsTableOnEveryUpdate;
+    }
+
+    /**
+     * Returns whether the words table should be cleaned on every update.
+     * If this setting is set to true, every index update will ensure the
+     * words table does not contain any entries without associated documents.
+     *
+     * @return bool
+     */
+    public function wordsTableShouldBeCleanedOnEveryUpdate(): bool
+    {
+        return $this->cleanWordsTableOnEveryUpdate;
+    }
+}

--- a/src/SearchConfiguration.php
+++ b/src/SearchConfiguration.php
@@ -27,7 +27,7 @@ class SearchConfiguration
     protected $requireMatchForAllTokens;
 
     /**
-     * SearchWeights constructor.
+     * SearchConfiguration constructor.
      *
      * @param float $inverseDocumentFrequencyWeight
      * @param float $termFrequencyWeight


### PR DESCRIPTION
With this PR, the indexer receives two performance upgrades of which one is optional but recommended.

**The first improvement** is that less update queries are run now. This could be achieved by grouping based on the update needs before performing the actual update. In other words, similar changes are now performed within the same query. Consider the following example:
```sql
UPDATE scout_words SET num_hits = num_hits - 2 WHERE id = 4;
UPDATE scout_words SET num_hits = num_hits - 2 WHERE id = 7;
UPDATE scout_words SET num_hits = num_hits - 3 WHERE id = 8;
```
In this case, we can reduce the queries to:
```sql
UPDATE scout_words SET num_hits = num_hits - 2 WHERE id IN (4, 7);
UPDATE scout_words SET num_hits = num_hits - 3 WHERE id = 8;
```
Because doing this means less round-trips to the database, the whole transaction is sped up.

**The second improvement** is that there is now an opt-out option for cleaning the `words` table on index updates. By default, as part of each index update, entries within the `words` table which do not reference any documents are removed:
```sql
DELETE FROM scout_words WHERE num_documents = 0;
```
Because this takes some time and a few word entries without associated documents do not hurt the performance of the search in a noticeable way, it is recommended to remove such entries using the new `CleanWordsTable` command on a regular basis instead.