### PR TITLE
Configurable transaction attempts to avoid failed jobs due to deadlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,14 @@ wildcard search). Returned are documents ordered by their score in descending or
 Obviously, this package does not provide a search engine which (even remotely) brings the performance and quality a professional search engine
 like Elasticsearch offers. This solution is meant for smaller to medium-sized projects which are in need of a rather simple-to-setup solution.
 
-One issue with this search engine is that it leads to issues if multiple queue workers work on the indexing concurrently (database will deadlock).
-Therefore, the whole system is implicitly limited by the amount of data one queue worker is able to index. For projects with frequent data updates,
-this may imply that only a few thousand documents are already enough to bring the engine to its limits. If your project has only few
-(and regular instead of piled) updates, millions of documents may not be an issue at all. In short: if it works for you depends on the use case.
+One issue with this search engine is that it can lead to issues if multiple queue workers work on the indexing concurrently (database will deadlock).
+To circumvent this issue, a the number of attempts used for transactions is configurable. By default, each transaction is tried a maximum of three
+times if a deadlock (or any other error) occurs. The more workers are updating the index at the same time, the more attempts might be needed in order
+for the jobs to succeed.
 
-_Note: Use the `queue` setting in your `config/scout.php` to use a queue for indexing on which only one queue worker is active, if you run into issues
-with deadlocks. Running index updates synchronously (not queued) may break your application altogether._
+_Note: Use the `queue` setting in your `config/scout.php` to use a queue for indexing on which only few queue workers are active,
+if you run into issues with deadlocks. Running index updates synchronously (not queued) may break your application altogether,
+since the amount of concurrency is pretty much out of your control._
 
 ## Disclaimer
 

--- a/config/scout-database.php
+++ b/config/scout-database.php
@@ -81,6 +81,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Indexing Transaction Attempts
+    |--------------------------------------------------------------------------
+    |
+    | When concurrent access occurs to data which is being updated by the
+    | indexer, be it by a second indexing process or a search query, indexing
+    | might terminate with a deadlocked transaction. To avoid such abortion,
+    | a transaction can be run with multiple attempts. It will only fail and
+    | result in an exception if all attempts fail.
+    |
+    | This number defines the attempts granted for all transactions which the
+    | package, specifically the indexer, uses. A too low value might cause
+    | failed jobs, while a too high value can waste valuable resources by
+    | retrying too often. A sane value and also the default is 3.
+    |
+    */
+
+    'transaction_attempts' => 3,
+
+    /*
+    |--------------------------------------------------------------------------
     | Search related Settings
     |--------------------------------------------------------------------------
     |

--- a/src/DatabaseIndexer.php
+++ b/src/DatabaseIndexer.php
@@ -90,7 +90,7 @@ class DatabaseIndexer
                     // Saving the result to the index.
                     $this->saveDataToIndex($preparedStem['model'], $preparedStem['stems']);
                 }
-            });
+            }, $this->indexingConfiguration->getTransactionAttempts());
         } catch (\Throwable $e) {
             throw new ScoutDatabaseException("Extending or updating search index failed.", 0, $e);
         }
@@ -130,7 +130,7 @@ class DatabaseIndexer
                 if ($this->indexingConfiguration->wordsTableShouldBeCleanedOnEveryUpdate()) {
                     $this->deleteWordsWithoutAssociatedDocuments();
                 }
-            });
+            }, $this->indexingConfiguration->getTransactionAttempts());
         } catch (\Throwable $e) {
             throw new ScoutDatabaseException("Deleting entries from search index failed.", 0, $e);
         }
@@ -156,7 +156,7 @@ class DatabaseIndexer
                 $this->connection->table($this->databaseHelper->wordsTable())
                     ->where('document_type', $model->searchableAs())
                     ->delete();
-            });
+            }, $this->indexingConfiguration->getTransactionAttempts());
         } catch (\Throwable $e) {
             throw new ScoutDatabaseException("Deleting all entries of type from search index failed.", 0, $e);
         }

--- a/src/IndexingConfiguration.php
+++ b/src/IndexingConfiguration.php
@@ -14,14 +14,19 @@ class IndexingConfiguration
     /** @var bool */
     protected $cleanWordsTableOnEveryUpdate;
 
+    /** @var int */
+    protected $transactionAttempts;
+
     /**
      * IndexingConfiguration constructor.
      *
      * @param bool $cleanWordsTableOnEveryUpdate
+     * @param int  $transactionAttempts
      */
-    public function __construct(bool $cleanWordsTableOnEveryUpdate)
+    public function __construct(bool $cleanWordsTableOnEveryUpdate, int $transactionAttempts = 1)
     {
         $this->cleanWordsTableOnEveryUpdate = $cleanWordsTableOnEveryUpdate;
+        $this->transactionAttempts          = $transactionAttempts;
     }
 
     /**
@@ -34,5 +39,16 @@ class IndexingConfiguration
     public function wordsTableShouldBeCleanedOnEveryUpdate(): bool
     {
         return $this->cleanWordsTableOnEveryUpdate;
+    }
+
+    /**
+     * Returns the number of attempts a transaction should be granted before
+     * throwing an exception in case of an error.
+     *
+     * @return int
+     */
+    public function getTransactionAttempts(): int
+    {
+        return $this->transactionAttempts;
     }
 }

--- a/src/ScoutDatabaseServiceProvider.php
+++ b/src/ScoutDatabaseServiceProvider.php
@@ -58,7 +58,8 @@ class ScoutDatabaseServiceProvider extends ServiceProvider
             $config = $app->make('config');
 
             return new IndexingConfiguration(
-                $config->get('scout-database.clean_words_table_on_every_update', true)
+                $config->get('scout-database.clean_words_table_on_every_update', true),
+                $config->get('scout-database.transaction_attempts', 1)
             );
         });
 


### PR DESCRIPTION
With this PR, a new configuration option has been added. It is now possible to configure the number of attempts which are granted to transactions. This means that each transaction will be run at most the configured number of times, if an exception occurs within the transaction.

The default for this new configuration parameter is `3`, although old installations (which are not updating their configuration file) will keep using the implicit value of `1` (a framework default).