### PR TITLE
Support PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php-versions }} tests on ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit:9.3.0
+          tools: phpunit:9.5.0
           coverage: pcov
 
       - name: Setup problem matchers for PHP

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-pdo": "*",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",


### PR DESCRIPTION
The PR adds support for PHP 8 and updates the `.github/workflows/tests.yml` pipeline to also build for PHP 8.0. We also use `phpunit/phpunit:9.5.0` instead of `v9.3.0`.