### PR TITLE
Improve query performance by replacing join

### DIFF
--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -122,9 +122,18 @@ class DatabaseSeeker
         // The actual search is performed entirely within the database.
         return $this->connection
             ->table('matches_with_score')
+            ->withExpression('documents_in_index', function (QueryBuilder $query) use ($model) {
+                $query->from($this->databaseHelper->indexTable())
+                    ->whereRaw("document_type = '{$model->searchableAs()}'")
+                    ->select([
+                        'document_type',
+                        DB::raw('COUNT(DISTINCT(document_id)) as cnt'),
+                    ])
+                    ->groupBy('document_type');
+            })
             ->withExpression('document_index', function (QueryBuilder $query) use ($model) {
                 $query->from($this->databaseHelper->indexTable())
-                    ->where('document_type', $model->searchableAs())
+                    ->whereRaw("document_type = '{$model->searchableAs()}'")
                     ->select([
                         'id',
                         'document_id',
@@ -132,23 +141,6 @@ class DatabaseSeeker
                         'length',
                         'num_hits',
                     ]);
-            })
-            ->withExpression('term_frequency', function (QueryBuilder $query) {
-                $query->from('document_index')
-                    ->select([
-                        'term',
-                        DB::raw('SUM(num_hits) as occurrences'),
-                    ])
-                    ->groupBy('term');
-            })
-            ->withExpression('documents_in_index', function (QueryBuilder $query) use ($model) {
-                $query->from($this->databaseHelper->indexTable())
-                    ->where('document_type', $model->searchableAs())
-                    ->select([
-                        'document_type',
-                        DB::raw('COUNT(DISTINCT(document_id)) as cnt'),
-                    ])
-                    ->groupBy('document_type');
             })
             ->withExpression('matching_terms', function (QueryBuilder $query) use ($keywords) {
                 $query->from('document_index')
@@ -171,31 +163,38 @@ class DatabaseSeeker
                     });
                 }
             })
+            ->withExpression('term_frequency', function (QueryBuilder $query) {
+                $query->from('document_index')
+                    ->select([
+                        'term',
+                        DB::raw('SUM(num_hits) as occurrences'),
+                    ])
+                    ->groupBy('term')
+                    ->whereIn('term', function (QueryBuilder $query) {
+                        $query->from('matching_terms')
+                            ->select('term');
+                    });
+            })
             ->withExpression('matches_with_score', function (QueryBuilder $query) {
                 $query->from('document_index', 'di')
                     ->join('term_frequency as tf', 'tf.term', '=', 'di.term')
-                    ->join('matching_terms as mt', 'mt.term', '=', 'di.term')
+                    ->leftJoin('matching_terms as mt', 'mt.term', '=', 'di.term')
                     ->select([
                         'di.document_id',
                         'di.term',
                     ])
                     ->selectRaw(
-                        '(' .
+                        'CASE WHEN mt.term IS NOT NULL THEN (' .
                             // inverse document frequency
-                            '(1 + LOG(? * (CAST((SELECT cnt FROM documents_in_index) as float) ' .
+                            "(1 + LOG({$this->searchConfiguration->getInverseDocumentFrequencyWeight()} * ((SELECT cnt FROM documents_in_index) " .
                                 '/ ((CASE WHEN tf.occurrences > 1 THEN tf.occurrences ELSE 1 END) + 1))))' .
                             '* (' .
                                 // weighted term frequency
-                                '(CAST(? as float) * SQRT(di.num_hits))' .
+                                "({$this->searchConfiguration->getTermFrequencyWeight()} * SQRT(di.num_hits))" .
                                 // term deviation (for wildcard search)
-                                '+ (CAST(? as float) * SQRT(CAST(1 as float) / (ABS(di.length - mt.length) + 1)))' .
+                                "+ ({$this->searchConfiguration->getTermDeviationWeight()} * SQRT(1.0 / (ABS(di.length - mt.length) + 1)))" .
                             ')' .
-                        ') as score',
-                        [
-                            $this->searchConfiguration->getInverseDocumentFrequencyWeight(),
-                            $this->searchConfiguration->getTermFrequencyWeight(),
-                            $this->searchConfiguration->getTermDeviationWeight(),
-                        ]
+                        ') ELSE 0 END as score'
                     );
             })
             ->select('document_id')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -69,6 +69,15 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'password' => env('DB_MYSQL_PASSWORD'),
             'prefix' => '',
         ]);
+        $app['config']->set('database.connections.pgsql', [
+            'driver' => 'pgsql',
+            'host' => env('DB_PGSQL_HOST', '127.0.0.1'),
+            'port' => env('DB_PGSQL_PORT', '5432'),
+            'database' => env('DB_PGSQL_DATABASE'),
+            'username' => env('DB_PGSQL_USERNAME'),
+            'password' => env('DB_PGSQL_PASSWORD'),
+            'prefix' => '',
+        ]);
     }
 
     /**


### PR DESCRIPTION
With this PR, the query performance is improved for the SQL Server driver drastically. Due to an issue with prepared statements, which lead to a bad query execution plan, bad performance was measurable (over 60 seconds with prepared statements, compared to <200ms without).

The solution is to avoid an inner join to matching terms and use a left join with a conditional 0-score instead.