### PR TITLE
Add tests for the DatabaseSeeker and fix small issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
           host port: 3306
           character set server: 'utf8mb4'
           collation server: 'utf8mb4_general_ci'
-          mysql version: '5.7'
+          mysql version: '8.0'
           mysql database: 'scoutdb'
           mysql user: 'scoutdb'
           mysql password: 's3cur3d123!'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         if: matrix.db-connection == 'mysql'
         run: sudo service mysql stop
 
-      - uses: mirromutth/mysql-action@v1.1
+      - uses: haltuf/mysql-action@master
         if: matrix.db-connection == 'mysql'
         with:
           host port: 3306
@@ -28,6 +28,7 @@ jobs:
           mysql database: 'scoutdb'
           mysql user: 'scoutdb'
           mysql password: 's3cur3d123!'
+          authentication plugin: 'mysql_native_password'
 
       - uses: harmon758/postgresql-action@v1
         if: matrix.db-connection == 'pgsql'

--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -201,7 +201,8 @@ class DatabaseSeeker
             ->select('document_id')
             ->groupBy('document_id')
             ->when($this->searchConfiguration->requireMatchForAllTokens(), function (QueryBuilder $query) use ($keywords) {
-                $query->havingRaw('COUNT(DISTINCT(term)) >= CAST(? as int)', [count($keywords)]);
+                $keywordCount = count($keywords);
+                $query->havingRaw("COUNT(DISTINCT(term)) >= {$keywordCount}");
             })
             ->orderByRaw('SQRT(COUNT(DISTINCT(term))) * SUM(score) DESC')
             ->when($pageSize !== null, function (QueryBuilder $query) use ($pageSize, $page) {

--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -186,11 +186,11 @@ class DatabaseSeeker
                     ->selectRaw(
                         'CASE WHEN mt.term IS NOT NULL THEN (' .
                             // inverse document frequency
-                            "(1 + LOG({$this->searchConfiguration->getInverseDocumentFrequencyWeight()} * ((SELECT cnt FROM documents_in_index) " .
+                            "(1 + LOG({$this->searchConfiguration->getInverseDocumentFrequencyWeight()} * (CAST((SELECT cnt FROM documents_in_index) as float) " .
                                 '/ ((CASE WHEN tf.occurrences > 1 THEN tf.occurrences ELSE 1 END) + 1))))' .
                             '* (' .
                                 // weighted term frequency
-                                "({$this->searchConfiguration->getTermFrequencyWeight()} * SQRT(di.num_hits))" .
+                                "({$this->searchConfiguration->getTermFrequencyWeight()} * SQRT(CAST(di.num_hits as float)))" .
                                 // term deviation (for wildcard search)
                                 "+ ({$this->searchConfiguration->getTermDeviationWeight()} * SQRT(1.0 / (ABS(di.length - mt.length) + 1)))" .
                             ')' .

--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -186,8 +186,9 @@ class DatabaseSeeker
                     ->selectRaw(
                         'CASE WHEN mt.term IS NOT NULL THEN (' .
                             // inverse document frequency
-                            "(1 + LOG({$this->searchConfiguration->getInverseDocumentFrequencyWeight()} * (CAST((SELECT cnt FROM documents_in_index) as float) " .
-                                '/ ((CASE WHEN tf.occurrences > 1 THEN tf.occurrences ELSE 1 END) + 1))))' .
+                            "(1 + LOG({$this->searchConfiguration->getInverseDocumentFrequencyWeight()} " .
+                                "* (CAST((SELECT cnt FROM documents_in_index) as float) " .
+                                    '/ ((CASE WHEN tf.occurrences > 1 THEN tf.occurrences ELSE 1 END) + 1))))' .
                             '* (' .
                                 // weighted term frequency
                                 "({$this->searchConfiguration->getTermFrequencyWeight()} * SQRT(CAST(di.num_hits as float)))" .

--- a/src/ScoutDatabaseServiceProvider.php
+++ b/src/ScoutDatabaseServiceProvider.php
@@ -101,7 +101,7 @@ class ScoutDatabaseServiceProvider extends ServiceProvider
             ], 'migrations');
         }
 
-        $this->app[EngineManager::class]->extend('database', function (Application $app) {
+        $this->app->make(EngineManager::class)->extend('database', function (Application $app) {
             /** @var ConfigRepository $config */
             $config = $app->make('config');
 

--- a/tests/DatabaseSeekerTest.php
+++ b/tests/DatabaseSeekerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Namoshek\Scout\Database\Tests;
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Scout\EngineManager;
+use Namoshek\Scout\Database\DatabaseSeeker;
+use Namoshek\Scout\Database\Tests\Stubs\User;
+
+/**
+ * Tests for the {@see DatabaseSeeker} class.
+ *
+ * @package Namoshek\Scout\Database\Tests
+ */
+class DatabaseSeekerTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Define the default configuration for search tests.
+        /** @var ConfigRepository $config */
+        $config = $this->app->make('config');
+
+        $config->set('scout-database.search.inverse_document_frequency_weight', 1);
+        $config->set('scout-database.search.term_frequency_weight', 1);
+        $config->set('scout-database.search.term_deviation_weight', 1);
+        $config->set('scout-database.search.wildcard_last_token', true);
+        $config->set('scout-database.search.require_match_for_all_tokens', false);
+
+        // By resolving our Scout driver, we setup a few things required for our tests to work properly.
+        // To be concrete, we need custom functions to be registered for our queries to work with sqlite properly.
+        $this->app->make(EngineManager::class)->driver('database');
+
+        // Seed test data.
+        $this->insertCommonTestDataInDatabase();
+    }
+
+    protected function insertCommonTestDataInDatabase(): void
+    {
+        /** @var \Illuminate\Database\ConnectionInterface $connection */
+        $connection = $this->app->make('db');
+
+        $connection->table('scout_index')->insert([
+            ['document_type' => 'user', 'document_id' => 1, 'term' => 'abc', 'length' => 3, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 2, 'term' => 'abc', 'length' => 3, 'num_hits' => 4],
+            ['document_type' => 'user', 'document_id' => 1, 'term' => 'def', 'length' => 3, 'num_hits' => 2],
+            ['document_type' => 'user', 'document_id' => 3, 'term' => 'fooo', 'length' => 4, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 4, 'term' => 'foo', 'length' => 3, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 5, 'term' => 'one', 'length' => 3, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 6, 'term' => 'euro', 'length' => 4, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 7, 'term' => 'euro', 'length' => 4, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 8, 'term' => 'cent', 'length' => 4, 'num_hits' => 1],
+            ['document_type' => 'post', 'document_id' => 1, 'term' => 'abc', 'length' => 3, 'num_hits' => 1],
+            ['document_type' => 'comment', 'document_id' => 3, 'term' => 'abc', 'length' => 3, 'num_hits' => 2],
+        ]);
+    }
+
+    public function test_finds_documents_of_searched_type_which_have_term_with_exact_match(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('abc'));
+
+        $this->assertSame(2, $result->getHits());
+        $this->assertEquals([2, 1], $result->getIdentifiers());
+    }
+
+    public function test_finds_documents_of_searched_type_which_have_term_beginning_with_string(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('ab'));
+
+        $this->assertSame(2, $result->getHits());
+        $this->assertEquals([2, 1], $result->getIdentifiers());
+    }
+
+    public function test_does_not_find_documents_if_wildcard_support_is_disabled_and_no_exact_match_is_given(): void
+    {
+        $this->app->make('config')->set('scout-database.search.wildcard_last_token', false);
+
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('ab'));
+
+        $this->assertSame(0, $result->getHits());
+        $this->assertEquals([], $result->getIdentifiers());
+    }
+
+    public function test_finds_no_documents_of_searched_type_if_no_term_matches(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('somethingnotexisting'));
+
+        $this->assertSame(0, $result->getHits());
+        $this->assertEquals([], $result->getIdentifiers());
+    }
+
+    public function test_finds_better_matching_documents_first(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('foo'));
+
+        $this->assertSame(2, $result->getHits());
+        $this->assertEquals([4, 3], $result->getIdentifiers());
+    }
+
+    public function test_finds_better_matching_documents_first_2(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('fo'));
+
+        $this->assertSame(2, $result->getHits());
+        $this->assertEquals([4, 3], $result->getIdentifiers());
+    }
+
+    public function test_finds_documents_with_single_matching_term_if_no_match_for_all_terms_is_required_per_configuration(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('one two three'));
+
+        $this->assertSame(1, $result->getHits());
+        $this->assertEquals([5], $result->getIdentifiers());
+    }
+
+    public function test_does_not_find_documents_with_single_matching_term_if_match_for_all_terms_is_required_per_configuration(): void
+    {
+        $this->app->make('config')->set('scout-database.search.require_match_for_all_tokens', true);
+
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('one two three'));
+
+        $this->assertSame(0, $result->getHits());
+        $this->assertEquals([], $result->getIdentifiers());
+    }
+
+    public function test_finds_documents_with_multiple_hits_of_a_term_before_documents_with_less_hits(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('abc'));
+
+        $this->assertSame(2, $result->getHits());
+        $this->assertEquals([2, 1], $result->getIdentifiers());
+    }
+
+    public function test_finds_documents_with_rare_terms_before_documents_with_common_terms(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('euro cent'));
+
+        $this->assertSame(3, $result->getHits());
+        $this->assertEquals([8, 6, 7], $result->getIdentifiers());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,7 +20,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function getPackageProviders($app): array
     {
         return [
+            \Laravel\Scout\ScoutServiceProvider::class,
             \Namoshek\Scout\Database\ScoutDatabaseServiceProvider::class,
+            \Staudenmeir\LaravelCte\DatabaseServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
The `DatabaseSeeker` has not been covered by tests so far. A few tests for common use cases and constraints (e.g. search result order) help to ensure some quality. Also, a small issue with a wrong score (infinity) being calculated has been fixed. This may have been an issue with SQLite only, though.

As part of this PR, the following constraints have been discovered and enforced using GitHub Actions:
- MySQL 5.7 is not supported, but only 8.0 onwards due to the CTE requirement as per [`staudemeir/laravel-cte`](https://github.com/staudenmeir/laravel-cte).
- The used MySQL GitHub Action did not support setting the `mysql_native_password` authentication plugin, which lead to the use of a fork.