### PR TITLE
Add more tests for the search part of the package

### DIFF
--- a/src/DatabaseEngine.php
+++ b/src/DatabaseEngine.php
@@ -19,10 +19,10 @@ use Laravel\Scout\Searchable;
 class DatabaseEngine extends Engine
 {
     /** @var DatabaseIndexer */
-    protected $indexer;
+    private $indexer;
 
     /** @var DatabaseSeeker */
-    protected $seeker;
+    private $seeker;
 
     /**
      * DatabaseEngine constructor.

--- a/src/DatabaseEngine.php
+++ b/src/DatabaseEngine.php
@@ -114,14 +114,20 @@ class DatabaseEngine extends Engine
      * @param SearchResult     $result
      * @param Model|Searchable $model
      * @return EloquentCollection
+     * @throws \InvalidArgumentException
      */
     public function map(Builder $builder, $result, $model): EloquentCollection
     {
-        if ($result->getHits() === 0) {
+        if (! $result instanceof SearchResult) {
+            throw new \InvalidArgumentException('The given result is not of the correct type.');
+        }
+
+        $objectIds = $result->getIdentifiers();
+
+        if (count($objectIds) === 0) {
             return EloquentCollection::make();
         }
 
-        $objectIds         = $result->getIdentifiers();
         $objectIdPositions = array_flip($objectIds);
 
         return $model->getScoutModelsByIds($builder, $objectIds)

--- a/src/DatabaseIndexer.php
+++ b/src/DatabaseIndexer.php
@@ -22,19 +22,19 @@ use Namoshek\Scout\Database\Support\DatabaseHelper;
 class DatabaseIndexer
 {
     /** @var ConnectionInterface */
-    protected $connection;
+    private $connection;
 
     /** @var Tokenizer */
-    protected $tokenizer;
+    private $tokenizer;
 
     /** @var Stemmer */
-    protected $stemmer;
+    private $stemmer;
 
     /** @var DatabaseHelper */
-    protected $databaseHelper;
+    private $databaseHelper;
 
     /** @var IndexingConfiguration */
-    protected $indexingConfiguration;
+    private $indexingConfiguration;
 
     /**
      * DatabaseIndexer constructor.
@@ -159,7 +159,7 @@ class DatabaseIndexer
      * @param array $data
      * @return string[][]
      */
-    protected function normalizeSearchableData(array $data): array
+    private function normalizeSearchableData(array $data): array
     {
         return array_map(function ($value) {
             $value = mb_strtolower((string) $value);
@@ -183,7 +183,7 @@ class DatabaseIndexer
      * @param Collection|Model[]|Searchable[] $models
      * @return Builder
      */
-    protected function addRawDocumentConstraintsToBuilder(Builder $builder, Collection $models): Builder
+    private function addRawDocumentConstraintsToBuilder(Builder $builder, Collection $models): Builder
     {
         $index = 0;
         foreach ($models as $model) {

--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -113,7 +113,7 @@ class DatabaseSeeker
 
         // First, we retrieve the paginated results.
         $results = $this->createSearchQuery($builder, $keywords)
-            ->orderByRaw('SQRT(COUNT(DISTINCT(term))) * SUM(score) DESC')
+            ->orderByRaw('SQRT(COUNT(DISTINCT(term))) * SUM(score) DESC, document_id ASC')
             ->when($limit !== null, function (QueryBuilder $query) use ($limit, $page) {
                 $query->offset(($page - 1) * $limit)
                     ->take($limit);

--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -21,19 +21,19 @@ use Namoshek\Scout\Database\Support\DatabaseHelper;
 class DatabaseSeeker
 {
     /** @var ConnectionInterface */
-    protected $connection;
+    private $connection;
 
     /** @var Tokenizer */
-    protected $tokenizer;
+    private $tokenizer;
 
     /** @var Stemmer */
-    protected $stemmer;
+    private $stemmer;
 
     /** @var DatabaseHelper */
-    protected $databaseHelper;
+    private $databaseHelper;
 
     /** @var SearchConfiguration */
-    protected $searchConfiguration;
+    private $searchConfiguration;
 
     /**
      * DatabaseSeeker constructor.
@@ -104,7 +104,7 @@ class DatabaseSeeker
      * @param int|null $limit
      * @return SearchResult
      */
-    protected function performSearch(Builder $builder, array $keywords, int $page, ?int $limit): SearchResult
+    private function performSearch(Builder $builder, array $keywords, int $page, ?int $limit): SearchResult
     {
         // Add a wildcard to the last search token if it is configured.
         if ($this->searchConfiguration->lastTokenShouldUseWildcard()) {

--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -127,7 +127,7 @@ class DatabaseSeeker
         // If no pagination is used, we already retrieved all hits.
         if ($limit !== null) {
             $totalHits = $this->connection
-                ->table($this->createSearchQuery($builder, $keywords))
+                ->table($this->createSearchQuery($builder, $keywords), 'inner')
                 ->count();
         }
 

--- a/src/IndexingConfiguration.php
+++ b/src/IndexingConfiguration.php
@@ -12,7 +12,7 @@ namespace Namoshek\Scout\Database;
 class IndexingConfiguration
 {
     /** @var int */
-    protected $transactionAttempts;
+    private $transactionAttempts;
 
     /**
      * IndexingConfiguration constructor.

--- a/src/SearchConfiguration.php
+++ b/src/SearchConfiguration.php
@@ -12,19 +12,19 @@ namespace Namoshek\Scout\Database;
 class SearchConfiguration
 {
     /** @var float */
-    protected $inverseDocumentFrequencyWeight;
+    private $inverseDocumentFrequencyWeight;
 
     /** @var float */
-    protected $termFrequencyWeight;
+    private $termFrequencyWeight;
 
     /** @var float */
-    protected $termDeviationWeight;
+    private $termDeviationWeight;
 
     /** @var bool */
-    protected $wildcardLastToken;
+    private $wildcardLastToken;
 
     /** @var bool */
-    protected $requireMatchForAllTokens;
+    private $requireMatchForAllTokens;
 
     /**
      * SearchConfiguration constructor.

--- a/src/SearchResult.php
+++ b/src/SearchResult.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Namoshek\Scout\Database;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Laravel\Scout\Builder;
 
 /**
@@ -12,7 +13,7 @@ use Laravel\Scout\Builder;
  *
  * @package Namoshek\Scout\Database
  */
-class SearchResult
+class SearchResult implements Arrayable
 {
     /** @var Builder */
     protected $builder;
@@ -50,6 +51,8 @@ class SearchResult
     /**
      * Gets an array containing the document identifiers returned by the search.
      * The array is sorted with the highest scoring documents first.
+     * This list may contain less items than indicated by {@see getHits()} if the query
+     * builder applied a limit (e.g. in case of pagination).
      *
      * @return array|int[]
      */
@@ -66,5 +69,16 @@ class SearchResult
     public function getHits(): int
     {
         return $this->hits;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray()
+    {
+        return [
+            'ids' => $this->getIdentifiers(),
+            'hits' => $this->getHits(),
+        ];
     }
 }

--- a/src/SearchResult.php
+++ b/src/SearchResult.php
@@ -16,13 +16,13 @@ use Laravel\Scout\Builder;
 class SearchResult implements Arrayable
 {
     /** @var Builder */
-    protected $builder;
+    private $builder;
 
     /** @var int[] */
-    protected $ids;
+    private $ids;
 
     /** @var int */
-    protected $hits;
+    private $hits;
 
     /**
      * SearchResult constructor.

--- a/src/Stemmer/SnowballStemmer.php
+++ b/src/Stemmer/SnowballStemmer.php
@@ -16,7 +16,7 @@ use Wamania\Snowball\StemmerFactory;
 abstract class SnowballStemmer implements Stemmer
 {
     /** @var \Wamania\Snowball\Stemmer\Stemmer */
-    protected $stemmer;
+    private $stemmer;
 
     /**
      * SnowballStemmer constructor.

--- a/src/Support/DatabaseHelper.php
+++ b/src/Support/DatabaseHelper.php
@@ -12,7 +12,7 @@ namespace Namoshek\Scout\Database\Support;
 class DatabaseHelper
 {
     /** @var string */
-    protected $prefix;
+    private $prefix;
 
     /**
      * DatabaseHelper constructor.

--- a/tests/DatabaseSeekerTest.php
+++ b/tests/DatabaseSeekerTest.php
@@ -63,8 +63,8 @@ class DatabaseSeekerTest extends TestCase
         ]);
 
         $connection->table('users')->insert([
-            ['id' => 1, 'name' => 'Max Mustermann', 'email' => 'max.mustermann@example.com', 'password' => '123456', 'remember_token' => now()],
-            ['id' => 2, 'name' => 'Mia Musterfrau', 'email' => 'mia.musterfrau@example.com', 'password' => '123456', 'remember_token' => now()],
+            ['name' => 'Max Mustermann', 'email' => 'max.mustermann@example.com', 'password' => '123456', 'remember_token' => now()],
+            ['name' => 'Mia Musterfrau', 'email' => 'mia.musterfrau@example.com', 'password' => '123456', 'remember_token' => now()],
         ]);
     }
 

--- a/tests/DatabaseSeekerTest.php
+++ b/tests/DatabaseSeekerTest.php
@@ -56,6 +56,11 @@ class DatabaseSeekerTest extends TestCase
             ['document_type' => 'user', 'document_id' => 6, 'term' => 'euro', 'length' => 4, 'num_hits' => 1],
             ['document_type' => 'user', 'document_id' => 7, 'term' => 'euro', 'length' => 4, 'num_hits' => 1],
             ['document_type' => 'user', 'document_id' => 8, 'term' => 'cent', 'length' => 4, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 100, 'term' => 'baz', 'length' => 3, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 101, 'term' => 'baz', 'length' => 3, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 102, 'term' => 'baz', 'length' => 3, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 103, 'term' => 'baz', 'length' => 3, 'num_hits' => 1],
+            ['document_type' => 'user', 'document_id' => 104, 'term' => 'baz', 'length' => 3, 'num_hits' => 1],
             ['document_type' => 'post', 'document_id' => 1, 'term' => 'abc', 'length' => 3, 'num_hits' => 1],
             ['document_type' => 'comment', 'document_id' => 3, 'term' => 'abc', 'length' => 3, 'num_hits' => 2],
         ]);
@@ -153,5 +158,31 @@ class DatabaseSeekerTest extends TestCase
 
         $this->assertSame(3, $result->getHits());
         $this->assertEquals([8, 6, 7], $result->getIdentifiers());
+    }
+
+    public function test_finds_limited_amount_of_documents_if_limit_is_set(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+        $result = $seeker->search(User::search('baz')->take(3));
+
+        $this->assertSame(3, $result->getHits());
+        $this->assertEquals([100, 101, 102], $result->getIdentifiers());
+    }
+
+    public function test_finds_paginated_documents_without_repetition_on_pages(): void
+    {
+        $seeker = $this->app->make(DatabaseSeeker::class);
+
+        $result = $seeker->search(User::search('baz')->take(2), 1, 2);
+        $this->assertSame(2, $result->getHits());
+        $this->assertEquals([100, 101], $result->getIdentifiers());
+
+        $result = $seeker->search(User::search('baz')->take(2), 2, 2);
+        $this->assertSame(2, $result->getHits());
+        $this->assertEquals([102, 103], $result->getIdentifiers());
+
+        $result = $seeker->search(User::search('baz')->take(2), 3, 2);
+        $this->assertSame(1, $result->getHits());
+        $this->assertEquals([104], $result->getIdentifiers());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -94,6 +94,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::setUp();
 
+        $this->loadLaravelMigrations();
         $this->loadMigrationsFrom(__DIR__ . '/../migrations');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -80,6 +80,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'password' => env('DB_PGSQL_PASSWORD'),
             'prefix' => '',
         ]);
+
+        // We use the database scout driver as default.
+        $app['config']->set('scout.driver', 'database');
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @noinspection PhpFullyQualifiedNameUsageInspection */
+/** @noinspection PhpMissingParamTypeInspection */
+
 declare(strict_types=1);
 
 namespace Namoshek\Scout\Database\Tests;


### PR DESCRIPTION
New tests cover and fix the pagination feature of Scout for this driver. Also the conversion from retrieved document indexes to document models has been covered by tests now. All in all, the tests are also simpler and more direct by emulating a runtime environment instead of skipping the `DatabaseEngine`.