### PR TITLE
Prepare release candiate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [pull_request]
+on: [push]
 
 jobs:
   test-all:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,32 @@ When you have done so, you can then apply the database migrations:
 php artisan migrate
 ```
 
+### Upgrading from `v0.x` to `v1.x`
+
+#### Migrations
+
+With the new version, the database schema has changed and new migrations need to be published using:
+
+```bash
+php artisan vendor:publish --provider="Namoshek\Scout\Database\ScoutDatabaseServiceProvider" --tag="migrations"
+```
+
+The same hint as mentioned above in the _Installation_ section applies to the newly published migrations as well.
+
+#### Config
+
+The configuration has been reduced slightly and you might want to compare the new configuration file with the old one to remove obsolete settings.
+Skipping this part has no negative impact on the performance of the Scout driver, though.
+
+#### Commands
+
+The `\Namoshek\Scout\Database\Commands\CleanWordsTable::class` command has been removed and you should un-schedule it, if you added it previously.
+
+#### Noteworthy
+
+Most occurrences of `protected` fields and methods have been changed to `private` to simplify development in regard to backwards-compatibility breaking changes in the future.
+If you have not been actively overriding parts of the implementation, this does not affect you at all.
+
 ## Configuration
 
 In order to instruct Scout to use the driver provided by this package, you need to change the `driver` option in `config/scout.php`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/namoshek/laravel-scout-database.svg?style=flat-square)](https://packagist.org/packages/namoshek/laravel-scout-database)
 [![Total Downloads](https://img.shields.io/packagist/dt/namoshek/laravel-scout-database.svg?style=flat-square)](https://packagist.org/packages/namoshek/laravel-scout-database)
+[![Tests](https://github.com/Namoshek/laravel-scout-database/workflows/Tests/badge.svg)](https://github.com/Namoshek/laravel-scout-database/actions?query=workflow%3ATests)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=namoshek_laravel-scout-database&metric=alert_status)](https://sonarcloud.io/dashboard?id=namoshek_laravel-scout-database)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=namoshek_laravel-scout-database&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=namoshek_laravel-scout-database)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=namoshek_laravel-scout-database&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=namoshek_laravel-scout-database)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=namoshek_laravel-scout-database&metric=security_rating)](https://sonarcloud.io/dashboard?id=namoshek_laravel-scout-database)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=namoshek_laravel-scout-database&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=namoshek_laravel-scout-database)
+[![License](https://poser.pugx.org/namoshek/laravel-scout-database/license)](https://packagist.org/packages/namoshek/laravel-scout-database)
 
 The package provides a generic Laravel Scout driver which performs full-text search on indexed model data using an SQL database as storage backend.
 Indexed data is stored in normalized form, allowing efficient search which does not require a full match.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,22 @@
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=namoshek_laravel-scout-database&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=namoshek_laravel-scout-database)
 [![License](https://poser.pugx.org/namoshek/laravel-scout-database/license)](https://packagist.org/packages/namoshek/laravel-scout-database)
 
-The package provides a generic Laravel Scout driver which performs full-text search on indexed model data using an SQL database as storage backend.
-Indexed data is stored in normalized form, allowing efficient search which does not require a full match.
+This package provides a generic Laravel Scout driver which performs full-text search on indexed model data using an SQL database as storage backend.
+Indexed data is stored in normalized form, allowing efficient and fuzzy search which does not require a full and/or exact match.
 
 This driver is an alternative to [`teamtnt/laravel-scout-tntsearch-driver`](https://github.com/teamtnt/laravel-scout-tntsearch-driver).
-The primary difference is that this driver provides less features (like geo search). Instead it works with all database systems supported
-by Laravel itself (which are basically all PDO drivers).
-Also the search algorithm is slightly different and fuzzy search is currently not implemented.
+The primary difference is that this driver provides fewer features (like geo search).
+Instead, it works with all database systems supported by Laravel itself (which are basically all PDO drivers).
+Also, the search algorithm is slightly different.
+
+All tests are run through GitHub Actions for PHP 7.3, 7.4 and 8.0 on the following database systems:
+- SQLite 3
+- MySQL 8.0
+- PostgreSQL 13.1
+- SQL Server 2017
+
+Actual limitations regarding supported database systems are mostly related to the use of _Common Table Expression_ using [staudenmeir/laravel-cte](https://github.com/staudenmeir/laravel-cte).
+Please make sure your database system is supported before using the package, or you might run into database errors.
 
 ## Installation
 
@@ -89,6 +98,7 @@ If you have different requirements for a stemmer, you can provide your own imple
 ## Usage
 
 The package follows the available use cases described in the [official Scout documentation](https://laravel.com/docs/7.x/scout).
+Please be aware of the listed [limitations](#limitations) though.
 
 ### How does it work?
 
@@ -124,23 +134,19 @@ wildcard search). Returned are documents ordered by their score in descending or
 Obviously, this package does not provide a search engine which (even remotely) brings the performance and quality a professional search engine
 like Elasticsearch offers. This solution is meant for smaller to medium-sized projects which are in need of a rather simple-to-setup solution.
 
+Also worth noting, the following Scout features are currently not implemented:
+- Soft Deletes
+- Search with custom conditions using `User::search('Max')->where('city', 'Bregenz')`
+- Search custom index using `User::search('Mustermann')->within('users_without_admins')`
+- Search with custom order using `User::search('Musterfrau')->orderBy('age', 'desc')`
+  - Implementing this feature would be difficult in combination with the scoring algorithm. Only the result of the database query could be ordered, while this could then lead to issues with pagination.
+
+### Known Issues
+
 One issue with this search engine is that it can lead to issues if multiple queue workers work on the indexing of a single document concurrently
 (database will deadlock).
 To circumvent this issue, a the number of attempts used for transactions is configurable. By default, each transaction is tried a maximum of three
 times if a deadlock (or any other error) occurs.
-
-_Note: Use the `queue` setting in your `config/scout.php` to use a queue for indexing on which only few queue workers are active,
-if you run into issues with deadlocks. Running index updates synchronously (not queued) may break your application altogether,
-since the amount of concurrency is pretty much out of your control._
-
-## Disclaimer
-
-The package has only been tested with Microsoft SQL Server as well as SQLite so far. The SQL functions used within raw query parts should be available
-for Microsoft SQL Server, MySql, PostgreSQL as well as SQLite. Polyfills for `log()` and `sqrt()` have been provided for SQLite, but they might
-not yield very good performance (to be honest, I've no experience with this part). If you come across issues with any of the database systems
-Laravel supports, please let me know.
-
-Noteworthy as well is that the search algorithm has not been tested with concrete test inputs, only with some real world data.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "ext-pdo": "*",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",

--- a/src/ScoutDatabaseServiceProvider.php
+++ b/src/ScoutDatabaseServiceProvider.php
@@ -79,12 +79,13 @@ class ScoutDatabaseServiceProvider extends ServiceProvider
      * Bootstrap any application services.
      *
      * @return void
+     * @throws \BadFunctionCallException
      */
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             if (!function_exists('config_path') || !function_exists('database_path')) {
-                throw new \Exception('config_path() and/or database_path() function not found. Is the Laravel framework installed?');
+                throw new \BadFunctionCallException('config_path() and/or database_path() function not found. Is the Laravel framework installed?');
             }
 
             $this->publishes([

--- a/src/ScoutDatabaseServiceProvider.php
+++ b/src/ScoutDatabaseServiceProvider.php
@@ -88,18 +88,8 @@ class ScoutDatabaseServiceProvider extends ServiceProvider
                 throw new \BadFunctionCallException('config_path() and/or database_path() function not found. Is the Laravel framework installed?');
             }
 
-            $this->publishes([
-                __DIR__.'/../config/scout-database.php' => config_path('scout-database.php'),
-            ], 'config');
-
-            $this->publishes([
-                __DIR__ . '/../migrations/0000_00_00_000000_create_scout_database_words_table.php' =>
-                    database_path('migrations/'.date('Y_m_d_His', time()).'_create_scout_database_words_table.php'),
-                __DIR__ . '/../migrations/0000_00_00_000001_create_scout_database_documents_table.php' =>
-                    database_path('migrations/'.date('Y_m_d_His', time()+1).'_create_scout_database_documents_table.php'),
-                __DIR__ . '/../migrations/0000_00_00_000002_create_scout_database_index_table.php' =>
-                    database_path('migrations/'.date('Y_m_d_His', time()+2).'_create_scout_database_index_table.php'),
-            ], 'migrations');
+            $this->publishConfig();
+            $this->publishMigrations();
         }
 
         $this->app->make(EngineManager::class)->extend('database', function (Application $app) {
@@ -126,5 +116,43 @@ class ScoutDatabaseServiceProvider extends ServiceProvider
 
             return new DatabaseEngine($indexer, $seeker);
         });
+    }
+
+    /**
+     * Publishes the package configuration file.
+     *
+     * @return void
+     */
+    private function publishConfig(): void
+    {
+        $this->publishes([
+            __DIR__.'/../config/scout-database.php' => config_path('scout-database.php'),
+        ], 'config');
+    }
+
+    /**
+     * Publishes all package migrations which have not been published yet.
+     *
+     * @return void
+     */
+    private function publishMigrations(): void
+    {
+        static $migrations = [
+            '0000_00_00_000000_create_scout_database_words_table.php' => '_create_scout_database_words_table.php',
+            '0000_00_00_000001_create_scout_database_documents_table.php' => '_create_scout_database_documents_table.php',
+            '0000_00_00_000002_create_scout_database_index_table.php' => '_create_scout_database_index_table.php',
+        ];
+
+        $index = 0;
+        foreach ($migrations as $originalName => $targetSuffix) {
+            // Migration files are only published if no migration files with similar names exist already.
+            if (count(glob(database_path("migrations/*{$targetSuffix}"))) === 0) {
+                $this->publishes([
+                    __DIR__."/../migrations/{$originalName}" => database_path('migrations/'.date('Y_m_d_His', time()+$index).$targetSuffix),
+                ], 'migrations');
+
+                $index++;
+            }
+        }
     }
 }


### PR DESCRIPTION
In preparation of a release candidate for `v1.0.0`, this PR tweaks some final bits. Short summary:
- Added SonarQube analysis and result badges to README.
- Updated README to reflect changes.
- Added _upgrading from `v0.x` to `v1.x`_ to README.
- Only new migrations are published when running the publish Artisan command multiple times.
- The minimum required PHP version is now `7.3`.
- The test workflow on GitHub Actions runs on every push and not only for pull requests.
- Integration tests are simplified a bit.