### PR TITLE
Use Dependabot for GitHub Actions and improve build pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,23 @@
 version: 2
+
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "composer"
+    directory: "/"
+    allow:
+      - dependency-type: "development"
+    schedule:
+      interval: "daily"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "composer dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "github actions"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             run-sonarqube-analysis: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,11 @@ jobs:
         operating-system: [ubuntu-latest]
         php-version: ['7.3', '7.4', '8.0', '8.1']
         db-connection: ['sqlite_inmemory', 'sqlite_file', 'mysql', 'pgsql', 'sqlsrv']
+        include:
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.1'
+            db-connection: 'sqlite_inmemory'
+            run-sonarqube-analysis: true
 
     steps:
       - uses: actions/checkout@v2
@@ -100,14 +105,14 @@ jobs:
           DB_SQLSRV_PASSWORD: ${{ secrets.TESTS_SQLSRV_DB_SECRET }}
 
       - name: Prepare paths for SonarQube analysis
-        if: matrix.php-version == '8.1' && matrix.db-connection == 'sqlite_inmemory'
+        if: matrix.run-sonarqube-analysis
         run: |
           sed -i "s|$GITHUB_WORKSPACE|/github/workspace|g" phpunit.coverage-clover.xml
           sed -i "s|$GITHUB_WORKSPACE|/github/workspace|g" phpunit.report-junit.xml
 
       - name: Run SonarQube analysis
         uses: sonarsource/sonarcloud-github-action@master
-        if: matrix.php-version == '8.1' && matrix.db-connection == 'sqlite_inmemory'
+        if: matrix.run-sonarqube-analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}


### PR DESCRIPTION
This PR enables Dependabot for GitHub Actions and also improves the build pipeline by using `actions/checkout@v3` and `actions/cache@v3`, as well as using a build variable to enable SonarQube analysis only on one run.