### PR TITLE
Run CI tests against PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['7.3', '7.4', '8.0', '8.1']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2']
         db-connection: ['sqlite_inmemory', 'sqlite_file', 'mysql', 'pgsql', 'sqlsrv']
         include:
           - operating-system: 'ubuntu-latest'
-            php-version: '8.1'
+            php-version: '8.2'
             db-connection: 'sqlite_inmemory'
             run-sonarqube-analysis: true
 


### PR DESCRIPTION
Currently, the tests are run against PHP `7.3`, `7.4`, `8.0` and `8.1`. This PR adds test runs for PHP `8.2`, as it is supported by the `composer.json` constraint `php:^8.0`.