### PR TITLE
Remove support for Laravel 6, 7 and 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     "require": {
         "php": "^8.0",
         "ext-pdo": "*",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "laravel/scout": "^7.0|^8.0|^9.0",
+        "illuminate/contracts": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/support": "^9.0",
+        "laravel/scout": "^9.0",
         "staudenmeir/laravel-cte": "^1.0",
         "wamania/php-stemmer": "^2.0|^3.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.3|^6.0",
+        "orchestra/testbench": "^7.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "scripts": {


### PR DESCRIPTION
According to the [official support policy](https://laravel.com/docs/9.x/releases#support-policy), Laravel 6 and 7 have reached their end of life already and Laravel 8 is soon to follow. This PR therefore removes support for those versions.