### PR TITLE
Add support for Laravel 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 .idea
+.phpunit.cache
 .phpunit.result.cache
 composer.lock
 phpunit.coverage*.xml

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     "require": {
         "php": "^8.0",
         "ext-pdo": "*",
-        "illuminate/contracts": "^9.0",
-        "illuminate/database": "^9.0",
-        "illuminate/support": "^9.0",
+        "illuminate/contracts": "^9.0|^10.0",
+        "illuminate/database": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
         "laravel/scout": "^9.0",
         "staudenmeir/laravel-cte": "^1.0",
         "wamania/php-stemmer": "^2.0|^3.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^7.0|^8.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "scripts": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    backupStaticProperties="false"
+    cacheDirectory=".phpunit.cache"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
 >
@@ -30,7 +30,7 @@
     </php>
     <testsuites>
         <testsuite name="Test">
-            <directory suffix=".php">tests</directory>
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
     <coverage>


### PR DESCRIPTION
This PR adds support for Laravel 10. No noticeable changes are required. The `phpunit.xml` format has been migrated to the new schema.