### PR TITLE
Support laravel/scout v9 and v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^9.0|^10.0",
         "illuminate/database": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",
-        "laravel/scout": "^9.0",
+        "laravel/scout": "^9.0|^10.0",
         "staudenmeir/laravel-cte": "^1.0",
         "wamania/php-stemmer": "^2.0|^3.0"
     },


### PR DESCRIPTION
This PR adds support for `laravel/scout:^10.0`. No changes are required. Support for `laravel/scout:^9.0` is therefore kept for the time being.