### PR TITLE
Add wildcards to each search token

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The options are described thoroughly in the file itself. By default, the package
 and the [`PorterStemmer`](src/Stemmer/PorterStemmer.php) which is suitable for the English language. The search adds a trailing wildcard to the
 last token and not all search terms need to be found in order for a document to show up in the results (there must be at least one match though).
 
+You may also add a wildcard to each search token by enabling `wildcard_all_tokens` in the config file altough this is not recommended for performance reasons.
+
 _A basic installation most likely does not require you to change any of these settings. Just to make sure, you should have a look at the
 `connection` option though. If you want to change this, do so before running the migrations or the tables will be created using the wrong
 database connection._

--- a/config/scout-database.php
+++ b/config/scout-database.php
@@ -169,6 +169,42 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Use Wildcard for all Search Tokens
+        |--------------------------------------------------------------------------
+        |
+        | This setting controls whether all tokens of a search query shoudld be
+        | handled using a wildcard instead of an exact match. This basically
+        | means that for a search input of "hell wor", the query will match
+        | documents containing "hell%" or "wor%" where % is the SQL wildcard of
+        | a "like" condition. The wildcard will only be applied for
+        | search tokens that have a minimum length of `wilcard_min_length`.
+        |
+        | Setting this to `true` will add a wildcard to the end of each search
+        | token. You may also set this to "both" to add wildcards to the beginning
+        | and the end of each search token, for example: "%hell%" and "%wor%.
+        |
+        | Note: Please not that changing this setting may negatively impact the
+        | performance of search queries. Also you might want to make sure that
+        | `require_match_for_all_tokens` is set to `false` when using this.
+        |
+        */
+
+        'wildcard_all_tokens' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Minimum Token Length to apply Wildcards
+        |--------------------------------------------------------------------------
+        |
+        | If `wildcard_all_tokens` is enabled this setting defines the minimum
+        | length search tokens must have before wildcards are applied.
+        |
+        */
+
+        'wildcard_min_length' => 3,
+
+        /*
+        |--------------------------------------------------------------------------
         | Require a Match for all Tokens
         |--------------------------------------------------------------------------
         |

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
     backupGlobals="false"
     backupStaticProperties="false"
     cacheDirectory=".phpunit.cache"
@@ -33,12 +33,12 @@
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
         <exclude>
             <directory suffix=".php">src/Stemmer</directory>
         </exclude>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -11,6 +11,7 @@ use Laravel\Scout\Builder;
 use Namoshek\Scout\Database\Contracts\Stemmer;
 use Namoshek\Scout\Database\Contracts\Tokenizer;
 use Namoshek\Scout\Database\Support\DatabaseHelper;
+use Illuminate\Support\Str;
 
 /**
  * The database seeker searches the database for collection items of a specific model,
@@ -122,7 +123,7 @@ class DatabaseSeeker
 
         // Add a wildcard to the last search token if it is configured.
         if ($this->searchConfiguration->lastTokenShouldUseWildcard()) {
-            $keywords[count($keywords) - 1] .= '%';
+            $keywords[count($keywords) - 1] = Str::finish($keywords[count($keywords) - 1], '%');
         }
 
         return $keywords;

--- a/src/ScoutDatabaseServiceProvider.php
+++ b/src/ScoutDatabaseServiceProvider.php
@@ -70,7 +70,7 @@ class ScoutDatabaseServiceProvider extends ServiceProvider
                 $config->get('scout-database.search.wildcard_last_token', true),
                 $config->get('scout-database.search.require_match_for_all_tokens', false)
             ))
-                ->usingWildcardsForAllToken($config->get('scout-database.search.wildcard_all_tokens', false))
+                ->usingWildcardsForAllTokens($config->get('scout-database.search.wildcard_all_tokens', false))
                 ->usingWildcardMinLength($config->get('scout-database.search.wildcard_min_length', 3));
         });
     }

--- a/src/ScoutDatabaseServiceProvider.php
+++ b/src/ScoutDatabaseServiceProvider.php
@@ -63,13 +63,15 @@ class ScoutDatabaseServiceProvider extends ServiceProvider
             /** @var ConfigRepository $config */
             $config = $app->make('config');
 
-            return new SearchConfiguration(
+            return (new SearchConfiguration(
                 $config->get('scout-database.search.inverse_document_frequency_weight', 1),
                 $config->get('scout-database.search.term_frequency_weight', 1),
                 $config->get('scout-database.search.term_deviation_weight', 1),
                 $config->get('scout-database.search.wildcard_last_token', true),
                 $config->get('scout-database.search.require_match_for_all_tokens', false)
-            );
+            ))
+                ->usingWildcardsForAllToken($config->get('scout-database.search.wildcard_all_tokens', false))
+                ->usingWildcardMinLength($config->get('scout-database.search.wildcard_min_length', 3));
         });
     }
 

--- a/src/ScoutDatabaseServiceProvider.php
+++ b/src/ScoutDatabaseServiceProvider.php
@@ -63,15 +63,15 @@ class ScoutDatabaseServiceProvider extends ServiceProvider
             /** @var ConfigRepository $config */
             $config = $app->make('config');
 
-            return (new SearchConfiguration(
+            return new SearchConfiguration(
                 $config->get('scout-database.search.inverse_document_frequency_weight', 1),
                 $config->get('scout-database.search.term_frequency_weight', 1),
                 $config->get('scout-database.search.term_deviation_weight', 1),
                 $config->get('scout-database.search.wildcard_last_token', true),
-                $config->get('scout-database.search.require_match_for_all_tokens', false)
-            ))
-                ->usingWildcardsForAllTokens($config->get('scout-database.search.wildcard_all_tokens', false))
-                ->usingWildcardMinLength($config->get('scout-database.search.wildcard_min_length', 3));
+                $config->get('scout-database.search.require_match_for_all_tokens', false),
+                $config->get('scout-database.search.wildcard_all_tokens', false),
+                $config->get('scout-database.search.wildcard_min_length', 3),
+            );
         });
     }
 

--- a/src/SearchConfiguration.php
+++ b/src/SearchConfiguration.php
@@ -11,10 +11,6 @@ namespace Namoshek\Scout\Database;
  */
 class SearchConfiguration
 {
-    private bool|string $wildcardAllTokens = false;
-
-    private int $wildcardMinLength = 3;
-
     /**
      * SearchConfiguration constructor.
      */
@@ -23,29 +19,11 @@ class SearchConfiguration
         private float $termFrequencyWeight,
         private float $termDeviationWeight,
         private bool $wildcardLastToken,
-        private bool $requireMatchForAllTokens
+        private bool $requireMatchForAllTokens,
+        private bool|string $wildcardAllTokens = false,
+        private int $wildcardMinLength = 3,
     )
     {
-    }
-
-    /**
-     * Define wether all tokens of a search query shall use a wildcard.
-     */
-    public function usingWildcardsForAllTokens(bool|string $wildcardAllTokens): self
-    {
-        $this->wildcardAllTokens = $wildcardAllTokens;
-
-        return $this;
-    }
-
-    /**
-     * Define minimum token length for using wildcards.
-     */
-    public function usingWildcardMinLength(int $length): self
-    {
-        $this->wildcardMinLength = $length;
-
-        return $this;
     }
 
     /**

--- a/src/SearchConfiguration.php
+++ b/src/SearchConfiguration.php
@@ -11,6 +11,10 @@ namespace Namoshek\Scout\Database;
  */
 class SearchConfiguration
 {
+    private bool|string $wildcardAllTokens = false;
+
+    private int $wildcardMinLength = 3;
+
     /**
      * SearchConfiguration constructor.
      */
@@ -22,6 +26,26 @@ class SearchConfiguration
         private bool $requireMatchForAllTokens
     )
     {
+    }
+
+    /**
+     * Define wether all tokens of a search query shall use a wildcard.
+     */
+    public function usingWildcardsForAllToken(bool|string $wildcardAllTokens): self
+    {
+        $this->wildcardAllTokens = $wildcardAllTokens;
+
+        return $this;
+    }
+
+    /**
+     * Define minimum token length for using wildcards.
+     */
+    public function usingWildcardMinLength(int $length): self
+    {
+        $this->wildcardMinLength = $length;
+
+        return $this;
     }
 
     /**
@@ -54,6 +78,22 @@ class SearchConfiguration
     public function lastTokenShouldUseWildcard(): bool
     {
         return $this->wildcardLastToken;
+    }
+
+    /**
+     * Returns whether all tokens of a search query shall use a wildcard.
+     */
+    public function allTokensShouldUseWildcard(): string|bool
+    {
+        return $this->wildcardAllTokens;
+    }
+
+    /**
+     * Returns th  minimum token length for using wildcards.
+     */
+    public function minimumLengthForWildcard(): int
+    {
+        return $this->wildcardMinLength;
     }
 
     /**

--- a/src/SearchConfiguration.php
+++ b/src/SearchConfiguration.php
@@ -31,7 +31,7 @@ class SearchConfiguration
     /**
      * Define wether all tokens of a search query shall use a wildcard.
      */
-    public function usingWildcardsForAllToken(bool|string $wildcardAllTokens): self
+    public function usingWildcardsForAllTokens(bool|string $wildcardAllTokens): self
     {
         $this->wildcardAllTokens = $wildcardAllTokens;
 

--- a/tests/ScopedDatabaseSeekerTest.php
+++ b/tests/ScopedDatabaseSeekerTest.php
@@ -9,7 +9,6 @@ namespace Namoshek\Scout\Database\Tests;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Namoshek\Scout\Database\DatabaseSeeker;
 use Namoshek\Scout\Database\SearchResult;
 use Namoshek\Scout\Database\Tests\Stubs\User;
 

--- a/tests/ScopedDatabaseSeekerTest.php
+++ b/tests/ScopedDatabaseSeekerTest.php
@@ -284,4 +284,62 @@ class ScopedDatabaseSeekerTest extends TestCase
 
         $this->assertEquals($builder, $result->getBuilder());
     }
+
+    public function test_does_not_find_documents_if_wildcard_all_tokens_is_disabled_and_no_exact_match_is_given(): void
+    {
+        $result = User::search('eur ent')->where('tenant_id', self::TENANT_ID_1)->keys();
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_finds_documents_if_wildcard_all_tokens_is_enabled_and_no_exact_match_is_given(): void
+    {
+        $this->app->make('config')->set('scout-database.search.wildcard_all_tokens', true);
+
+        $result = User::search('eur ent')->where('tenant_id', self::TENANT_ID_1)->keys();
+
+        $this->assertEquals([6, 7], $result->toArray());
+    }
+
+    public function test_finds_documents_if_wildcard_all_tokens_is_set_to_both(): void
+    {
+        $this->app->make('config')->set('scout-database.search.wildcard_all_tokens', 'both');
+
+        $result = User::search('eur ent')->where('tenant_id', self::TENANT_ID_1)->keys();
+
+        $this->assertEquals([8, 6, 7], $result->toArray());
+    }
+
+    public function test_does_not_find_documents_by_wildcard_if_minimum_token_length_is_not_reached(): void
+    {
+        $this->app->make('config')->set('scout-database.search.wildcard_all_tokens', 'both');
+        $this->app->make('config')->set('scout-database.search.wildcard_min_length', 4);
+
+        $result = User::search('eur ent')->where('tenant_id', self::TENANT_ID_1)->keys();
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_finds_documents_by_wildcard_if_minimum_token_length_is_reached(): void
+    {
+        $this->app->make('config')->set('scout-database.search.wildcard_all_tokens', 'both');
+        $this->app->make('config')->set('scout-database.search.wildcard_min_length', 4);
+
+        $result = User::search('ello abc xamp')->where('tenant_id', self::TENANT_ID_1)->keys();
+        $this->assertEquals([2, 11, 1, 10], $result->toArray());
+
+        $result = User::search('ello abc xamp')->where('tenant_id', self::TENANT_ID_2)->keys();
+        $this->assertEquals([3], $result->toArray());
+    }
+
+    public function test_adds_wildcard_to_last_token_even_if_minimum_length_is_not_reached(): void
+    {
+        $this->app->make('config')->set('scout-database.search.wildcard_all_tokens', 'both');
+        $this->app->make('config')->set('scout-database.search.wildcard_min_length', 7);
+        $this->app->make('config')->set('scout-database.search.wildcard_last_token', true);
+
+        $result = User::search('ello examp')->where('tenant_id', self::TENANT_ID_2)->keys();
+
+        $this->assertEquals([3], $result->toArray());
+    }
 }


### PR DESCRIPTION
This PR resolves #47 by adding a new config setting `wildcard_all_tokens` which defaults to `false` and a setting `wildcard_min_length` which defines a minimum length for tokens before wildcards are applied.

I migratet the phpunit XML to the new version. If this is undesired, let me know and I will revert the commit.

Excerpt from the config file:

```
This setting controls whether all tokens of a search query shoudld be
handled using a wildcard instead of an exact match. This basically
means that for a search input of "hell wor", the query will match
documents containing "hell%" or "wor%" where % is the SQL wildcard of
a "like" condition. The wildcard will only be applied for
search tokens that have a minimum length of `wilcard_min_length`.
     
Setting this to `true` will add a wildcard to the end of each search
token. You may also set this to "both" to add wildcards to the beginning
and the end of each search token, for example: "%hell%" and "%wor%.
       
Note: Please not that changing this setting may negatively impact the
performance of search queries. Also you might want to make sure that
`require_match_for_all_tokens` is set to `false` when using this.
```

I added some test cases:

```
 ✔ Does not find documents if wildcard all tokens is disabled and no exact match is given
 ✔ Finds documents if wildcard all tokens is enabled and no exact match is given
 ✔ Finds documents if wildcard all tokens is set to both
 ✔ Does not find documents by wildcard if minimum token length is not reached
 ✔ Finds documents by wildcard if minimum token length is reached
 ✔ Adds wildcard to last token even if minimum length is not reached
```