### PR TITLE
CI: install sqlsrv & pdo_sqlsrv extensions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: phpunit:9.5.0
           coverage: pcov
+          extensions: sqlsrv, pdo_sqlsrv
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"


### PR DESCRIPTION
Adds the `sqlsrv` and `pdo_sqlsrv` extensions for PHP to the CI build. There seems to have been an implicit change (missing drivers) between Ubuntu 22.04 and Ubuntu 24.04 due to the use of `ubuntu-latest`..