### PR TITLE
Use explicit nullable type

### DIFF
--- a/src/DatabaseSeeker.php
+++ b/src/DatabaseSeeker.php
@@ -50,7 +50,7 @@ class DatabaseSeeker
      * @param int      $page
      * @param int|null $pageSize
      */
-    public function search(Builder $builder, int $page = 1, int $pageSize = null): SearchResult
+    public function search(Builder $builder, int $page = 1, ?int $pageSize = null): SearchResult
     {
         /** @var int|null $limit */
         $limit = $pageSize ?? $builder->limit;
@@ -74,7 +74,7 @@ class DatabaseSeeker
      *
      * @param string[] $keywords
      */
-    private function performSearch(Builder $builder, array $keywords, int $page, ?int $limit): SearchResult
+    private function performSearch(Builder $builder, array $keywords, int $page, ?int $limit = null): SearchResult
     {
         $keywords = $this->addWildcards($keywords);
 

--- a/src/SearchResult.php
+++ b/src/SearchResult.php
@@ -25,9 +25,8 @@ class SearchResult implements Arrayable
     public function __construct(
         private Builder $builder,
         private array $ids,
-        int $hits = null
-    )
-    {
+        ?int $hits = null
+    ) {
         $this->hits = $hits ?? count($ids);
     }
 


### PR DESCRIPTION
Use explicit nullable type to prevent deprecation warning:

```
Namoshek\Scout\Database\DatabaseSeeker::search(): Implicitly marking parameter $pageSize as nullable is deprecated, the explicit nullable type must be used instead in vendor/namoshek/laravel-scout-database/src/DatabaseSeeker.php on line 53.
```